### PR TITLE
[Refactor/#169] 제휴 상세 조회 api 리팩토링

### DIFF
--- a/src/main/java/com/assu/server/domain/partnership/dto/PartnershipResponseDTO.java
+++ b/src/main/java/com/assu/server/domain/partnership/dto/PartnershipResponseDTO.java
@@ -26,7 +26,6 @@ public class PartnershipResponseDTO {
         private Long storeId;
         private String storeName;
         private String adminName;
-        private Boolean activated;
         private ActivationStatus isActivated;
         private List<PartnershipOptionResponseDTO> options;
     }
@@ -135,7 +134,13 @@ public class PartnershipResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class GetPartnershipDetailResponseDTO {
+        private Long partnershipId;
         private LocalDateTime updatedAt;
-        private WritePartnershipResponseDTO responseInfo;
+        private LocalDate partnershipPeriodStart;
+        private LocalDate partnershipPeriodEnd;
+        private Long adminId;
+        private Long partnerId;
+        private Long storeId;
+        private List<PartnershipOptionResponseDTO> options;
     }
 }

--- a/src/main/java/com/assu/server/domain/partnership/entity/Goods.java
+++ b/src/main/java/com/assu/server/domain/partnership/entity/Goods.java
@@ -1,5 +1,6 @@
 package com.assu.server.domain.partnership.entity;
 
+import com.assu.server.domain.common.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -19,7 +20,7 @@ import lombok.*;
 @NoArgsConstructor
 @Builder
 @AllArgsConstructor
-public class Goods {
+public class Goods extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #169 

## 📝작업 내용
- 상세조회 Response DTO 형식 수정
- Goods가 BaseEntity 상속받아 updatedAt 필드를 갖도록 수정
- paper, paperContent, Goods 중 가장 최근에 업데이트 된 엔티티의 updatedAt을 가져오도록 수정


## 🔎코드 설명(스크린샷(선택))
<img width="393" height="493" alt="image" src="https://github.com/user-attachments/assets/557f62f9-ff5e-42f5-955c-59509e0389a6" />

>dto에 updatedAt 필드 추가
